### PR TITLE
feat(client): Multifile Download v1

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -203,6 +203,42 @@ func (fc *FClient) MakeDirectory(dirname string) (err error) {
 	return nil
 }
 
+// function designed to download multiple files at one time.
+//
+// this will return a map containing the filenames and an associated
+// error. if no errors occurred, the map will be empty.
+func (fc *FClient) MultifileDownload(targets []string) (errs map[string]error) {
+	var err error
+	var target string
+
+	// initialize the return map to avoid nil reference errors.
+	errs = make(map[string]error)
+
+	// loop through each specified file and attempt a download.
+	// if successful, no entry will be added to the errs map.
+	// if an error occurs, the error will be attached to the
+	// filename via the errs map.
+	for _, target = range targets {
+
+		// if the current filename is an empty string or only
+		// contains non-printable characters, ignore it and
+		// move to the next filename.
+		target = strings.TrimSpace(target)
+		if len(target) < 1 {
+			continue
+		}
+
+		// attempt to download the file. if an error occurs,
+		// attach it to the filename via the map.
+		err = fc.DownloadFile(&filehandler.FileRequest{Filename: target})
+		if err != nil {
+			errs[target] = err
+		}
+	}
+
+	return errs
+}
+
 // function designed to check whether the server is up and able
 // to be contacted.
 func (fc *FClient) Ping() (roundtrip time.Duration, err error) {


### PR DESCRIPTION
## Description

The first version of the multifile download functionality has been added to the client. This will return a map (`map[string]error`) containing any errors that occurred while attempting to download the target files. 

## Associated Issues

This PR closes #19 