### PR TITLE
feat(server): multifile download v2

### DIFF
--- a/server/internal/defaults/constants.go
+++ b/server/internal/defaults/constants.go
@@ -1,5 +1,7 @@
 package defaults
 
+import "time"
+
 const DEFAULT_DEBUG bool = false
 const DEFAULT_LISTENADDR string = "0.0.0.0"
 const DEFAULT_LISTENPORT int = 8999
@@ -12,3 +14,5 @@ const FTYPE_UPLOAD string = "upload"
 
 const DEFAULT_MAX_DOWNLOADS int = 20
 const DEFAULT_MAX_UPLOADS int = 20
+
+const DEFAULT_TRANSFER_TIMEOUT time.Duration = 20 * time.Minute

--- a/server/internal/defaults/constants.go
+++ b/server/internal/defaults/constants.go
@@ -9,3 +9,6 @@ const DIR_DOWNLOADS string = ""
 
 const FTYPE_DOWNLOAD string = "download"
 const FTYPE_UPLOAD string = "upload"
+
+const DEFAULT_MAX_DOWNLOADS int = 20
+const DEFAULT_MAX_UPLOADS int = 20

--- a/server/internal/messages/messages.go
+++ b/server/internal/messages/messages.go
@@ -3,6 +3,7 @@ package messages
 const COPY_COMPLETE string = "copy complete."
 const COPY_IN_PROGRESS string = "copying data to destination ..."
 
+const DBG_ACTIVE_DOWNLOADS string = "active downloads %s"
 const DBG_DELETING_FILE string = "deleting \"%s\" ..."
 const DBG_DELETE_SUCCESS string = "file successfully deleted"
 const DBG_FILENAME string = "filename: %s"

--- a/server/internal/messages/messages.go
+++ b/server/internal/messages/messages.go
@@ -3,7 +3,8 @@ package messages
 const COPY_COMPLETE string = "copy complete."
 const COPY_IN_PROGRESS string = "copying data to destination ..."
 
-const DBG_ACTIVE_DOWNLOADS string = "active downloads %d"
+const DBG_ACTIVE_DOWNLOADS string = "active downloads: %d"
+const DBG_ACTIVE_UPLOADS string = "active uploads: %d"
 const DBG_DELETING_FILE string = "deleting \"%s\" ..."
 const DBG_DELETE_SUCCESS string = "file successfully deleted"
 const DBG_FILENAME string = "filename: %s"

--- a/server/internal/messages/messages.go
+++ b/server/internal/messages/messages.go
@@ -32,6 +32,7 @@ const ERR_RECV string = "[RECV] %s"
 const ERR_SERVE string = "[SERVE] %s\n"
 const ERR_TEMP string = "[TEMP] %s"
 const ERR_TRANSFER_MIN string = "value must be one or greater"
+const ERR_TRANSFER_TIMEOUT string = "file transfer exceeded maximum allowed time"
 
 const FILE_DELETED string = "file successfully deleted"
 const FILE_SENT string = "file successfully transmitted"

--- a/server/internal/messages/messages.go
+++ b/server/internal/messages/messages.go
@@ -31,6 +31,7 @@ const ERR_REMOVE_TEMP string = "[REMOVETMP] %s"
 const ERR_RECV string = "[RECV] %s"
 const ERR_SERVE string = "[SERVE] %s\n"
 const ERR_TEMP string = "[TEMP] %s"
+const ERR_TIMEOUT_VALUE string = "timeout value must be at least one second"
 const ERR_TRANSFER_MIN string = "value must be one or greater"
 const ERR_TRANSFER_TIMEOUT string = "file transfer exceeded maximum allowed time"
 

--- a/server/internal/messages/messages.go
+++ b/server/internal/messages/messages.go
@@ -31,6 +31,7 @@ const ERR_REMOVE_TEMP string = "[REMOVETMP] %s"
 const ERR_RECV string = "[RECV] %s"
 const ERR_SERVE string = "[SERVE] %s\n"
 const ERR_TEMP string = "[TEMP] %s"
+const ERR_TRANSFER_MIN string = "value must be one or greater"
 
 const FILE_DELETED string = "file successfully deleted"
 const FILE_SENT string = "file successfully transmitted"

--- a/server/internal/messages/messages.go
+++ b/server/internal/messages/messages.go
@@ -3,7 +3,7 @@ package messages
 const COPY_COMPLETE string = "copy complete."
 const COPY_IN_PROGRESS string = "copying data to destination ..."
 
-const DBG_ACTIVE_DOWNLOADS string = "active downloads %s"
+const DBG_ACTIVE_DOWNLOADS string = "active downloads %d"
 const DBG_DELETING_FILE string = "deleting \"%s\" ..."
 const DBG_DELETE_SUCCESS string = "file successfully deleted"
 const DBG_FILENAME string = "filename: %s"

--- a/server/internal/ofstypes/structs.go
+++ b/server/internal/ofstypes/structs.go
@@ -12,9 +12,11 @@ type TransferConfig struct {
 }
 
 type downloadConfig struct {
-	DownSem chan struct{}
+	ActiveDownloads int
+	DownSem         chan struct{}
 }
 
 type uploadConfig struct {
-	UpSem chan struct{}
+	ActiveUploads int
+	UpSem         chan struct{}
 }

--- a/server/internal/ofstypes/structs.go
+++ b/server/internal/ofstypes/structs.go
@@ -2,7 +2,10 @@
 // the Osgood File Server.
 package ofstypes
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 type TransferConfig struct {
 	downloadConfig
@@ -13,10 +16,12 @@ type TransferConfig struct {
 
 type downloadConfig struct {
 	ActiveDownloads int
+	DownMut         *sync.Mutex
 	DownSem         chan struct{}
 }
 
 type uploadConfig struct {
 	ActiveUploads int
+	UpMut         *sync.Mutex
 	UpSem         chan struct{}
 }

--- a/server/internal/ofstypes/structs.go
+++ b/server/internal/ofstypes/structs.go
@@ -1,0 +1,20 @@
+// module designed to hold the internal types specific to
+// the Osgood File Server.
+package ofstypes
+
+import "time"
+
+type TransferConfig struct {
+	downloadConfig
+	uploadConfig
+
+	TransferTimeout time.Duration
+}
+
+type downloadConfig struct {
+	DownSem chan struct{}
+}
+
+type uploadConfig struct {
+	UpSem chan struct{}
+}

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/thomas-osgood/OGOR/output"
@@ -69,8 +70,10 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	srv.rootdir = defaults.Rootdir
 	srv.transferCfg.ActiveDownloads = 0
 	srv.transferCfg.ActiveUploads = 0
+	srv.transferCfg.DownMut = new(sync.Mutex)
 	srv.transferCfg.DownSem = make(chan struct{}, defaults.MaxDownloads)
 	srv.transferCfg.TransferTimeout = defaults.TransferTimeout
+	srv.transferCfg.UpMut = new(sync.Mutex)
 	srv.transferCfg.UpSem = make(chan struct{}, defaults.MaxUploads)
 	srv.uploadsdir = defaults.Uploadsdir
 

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/thomas-osgood/OGOR/output"
 	ofsdefaults "github.com/thomas-osgood/ofs/server/internal/defaults"
@@ -158,6 +159,19 @@ func WithMaxUploads(max int) FSrvOptFunc {
 		}
 
 		fo.MaxUploads = max
+
+		return nil
+	}
+}
+
+// set the transfer timeout value for the server.
+func WithTransferTimeout(timeout time.Duration) FSrvOptFunc {
+	return func(fo *FServerOption) error {
+		if timeout < (1 * time.Second) {
+			return fmt.Errorf(ofsmessages.ERR_TIMEOUT_VALUE)
+		}
+
+		fo.TransferTimeout = timeout
 
 		return nil
 	}

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -133,6 +133,34 @@ func WithDownloadsDir(dirname string) FSrvOptFunc {
 	}
 }
 
+// set the maximum number of concurrent downloads allowed
+// at one time.
+func WithMaxDownloads(max int) FSrvOptFunc {
+	return func(fo *FServerOption) error {
+		if max < 1 {
+			return fmt.Errorf(ofsmessages.ERR_TRANSFER_MIN)
+		}
+
+		fo.MaxDownloads = max
+
+		return nil
+	}
+}
+
+// set the maximum number of concurrent uploads allowed
+// at one time.
+func WithMaxUploads(max int) FSrvOptFunc {
+	return func(fo *FServerOption) error {
+		if max < 1 {
+			return fmt.Errorf(ofsmessages.ERR_TRANSFER_MIN)
+		}
+
+		fo.MaxUploads = max
+
+		return nil
+	}
+}
+
 // set the uploads directory within the root directory.
 func WithUploadsDir(dirname string) FSrvOptFunc {
 	return func(fo *FServerOption) error {

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -36,6 +36,8 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	defaults = FServerOption{
 		Debug:        ofsdefaults.DEFAULT_DEBUG,
 		Downloadsdir: ofsdefaults.DIR_DOWNLOADS,
+		MaxDownloads: ofsdefaults.DEFAULT_MAX_DOWNLOADS,
+		MaxUploads:   ofsdefaults.DEFAULT_MAX_UPLOADS,
 		Rootdir:      rootdir,
 		Uploadsdir:   ofsdefaults.DIR_UPLOADS,
 	}
@@ -63,6 +65,8 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	srv.debug = defaults.Debug
 	srv.downloadsdir = defaults.Downloadsdir
 	srv.rootdir = defaults.Rootdir
+	srv.transferCfg.DownSem = make(chan struct{}, defaults.MaxDownloads)
+	srv.transferCfg.UpSem = make(chan struct{}, defaults.MaxUploads)
 	srv.uploadsdir = defaults.Uploadsdir
 
 	srv.printer, err = output.NewOutputter()

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -35,12 +35,13 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	}
 
 	defaults = FServerOption{
-		Debug:        ofsdefaults.DEFAULT_DEBUG,
-		Downloadsdir: ofsdefaults.DIR_DOWNLOADS,
-		MaxDownloads: ofsdefaults.DEFAULT_MAX_DOWNLOADS,
-		MaxUploads:   ofsdefaults.DEFAULT_MAX_UPLOADS,
-		Rootdir:      rootdir,
-		Uploadsdir:   ofsdefaults.DIR_UPLOADS,
+		Debug:           ofsdefaults.DEFAULT_DEBUG,
+		Downloadsdir:    ofsdefaults.DIR_DOWNLOADS,
+		MaxDownloads:    ofsdefaults.DEFAULT_MAX_DOWNLOADS,
+		MaxUploads:      ofsdefaults.DEFAULT_MAX_UPLOADS,
+		Rootdir:         rootdir,
+		TransferTimeout: ofsdefaults.DEFAULT_TRANSFER_TIMEOUT,
+		Uploadsdir:      ofsdefaults.DIR_UPLOADS,
 	}
 
 	// set the user-defined configuration options.
@@ -69,6 +70,7 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	srv.transferCfg.ActiveDownloads = 0
 	srv.transferCfg.ActiveUploads = 0
 	srv.transferCfg.DownSem = make(chan struct{}, defaults.MaxDownloads)
+	srv.transferCfg.TransferTimeout = defaults.TransferTimeout
 	srv.transferCfg.UpSem = make(chan struct{}, defaults.MaxUploads)
 	srv.uploadsdir = defaults.Uploadsdir
 

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -65,6 +65,8 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	srv.debug = defaults.Debug
 	srv.downloadsdir = defaults.Downloadsdir
 	srv.rootdir = defaults.Rootdir
+	srv.transferCfg.ActiveDownloads = 0
+	srv.transferCfg.ActiveUploads = 0
 	srv.transferCfg.DownSem = make(chan struct{}, defaults.MaxDownloads)
 	srv.transferCfg.UpSem = make(chan struct{}, defaults.MaxUploads)
 	srv.uploadsdir = defaults.Uploadsdir

--- a/server/server.go
+++ b/server/server.go
@@ -60,6 +60,9 @@ func (fsrv *FServer) DownloadFile(srv filehandler.Fileservice_DownloadFileServer
 	var filename string
 	var tmpname string
 
+	fsrv.increaseActiveDownloads()
+	defer fsrv.decreaseActiveDownloads()
+
 	fsrv.debugMessage(ofsmessages.DBG_IN_DOWNLOAD)
 
 	filename, err = ofsutils.ReadFilenameMD(srv.Context())
@@ -202,6 +205,9 @@ func (fsrv *FServer) UploadFile(req *filehandler.FileRequest, srv filehandler.Fi
 	var fptr *os.File
 	var md metadata.MD = make(metadata.MD)
 	var targetfile string = fsrv.cleanFilename(req.GetFilename(), ofsdefaults.FTYPE_UPLOAD)
+
+	fsrv.increaseActiveUploads()
+	defer fsrv.decreaseActiveUploads()
 
 	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_FILE_REQUEST, targetfile))
 

--- a/server/serverprivate.go
+++ b/server/serverprivate.go
@@ -93,18 +93,28 @@ func (fsrv *FServer) debugMessageSuc(message string) {
 // function designed to deccrement the number of "activedownloads"
 // for the client.
 func (fsrv *FServer) decreaseActiveDownloads() {
+	// enter critical section.
+	fsrv.transferCfg.DownMut.Lock()
+	defer fsrv.transferCfg.DownMut.Unlock()
+
 	// decrease active downloads and semaphore.
 	fsrv.transferCfg.ActiveDownloads--
 	<-fsrv.transferCfg.DownSem
+
 	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_DOWNLOADS, fsrv.transferCfg.ActiveDownloads))
 }
 
 // function designed to deccrement the number of "activeuploads"
 // for the client.
 func (fsrv *FServer) decreaseActiveUploads() {
+	// enter critical section.
+	fsrv.transferCfg.UpMut.Lock()
+	defer fsrv.transferCfg.UpMut.Unlock()
+
 	// decrease active uploads and semaphore.
 	fsrv.transferCfg.ActiveUploads--
 	<-fsrv.transferCfg.UpSem
+
 	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_UPLOADS, fsrv.transferCfg.ActiveUploads))
 }
 
@@ -133,6 +143,11 @@ func (fsrv *FServer) increaseActiveDownloads() {
 	// wait for room in semaphore, then increase
 	// the semaphore and active uploads.
 	fsrv.transferCfg.DownSem <- struct{}{}
+
+	// enter critical section.
+	fsrv.transferCfg.DownMut.Lock()
+	defer fsrv.transferCfg.DownMut.Unlock()
+
 	fsrv.transferCfg.ActiveDownloads++
 	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_DOWNLOADS, fsrv.transferCfg.ActiveDownloads))
 }
@@ -143,6 +158,11 @@ func (fsrv *FServer) increaseActiveUploads() {
 	// wait for room in semaphore, then increase
 	// the semaphore and active uploads.
 	fsrv.transferCfg.UpSem <- struct{}{}
+
+	// enter critical section.
+	fsrv.transferCfg.UpMut.Lock()
+	defer fsrv.transferCfg.UpMut.Unlock()
+
 	fsrv.transferCfg.ActiveUploads++
 	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_UPLOADS, fsrv.transferCfg.ActiveUploads))
 }

--- a/server/serverprivate.go
+++ b/server/serverprivate.go
@@ -96,6 +96,7 @@ func (fsrv *FServer) decreaseActiveDownloads() {
 	// decrease active downloads and semaphore.
 	fsrv.transferCfg.ActiveDownloads--
 	<-fsrv.transferCfg.DownSem
+	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_DOWNLOADS, fsrv.transferCfg.ActiveDownloads))
 }
 
 // function designed to deccrement the number of "activeuploads"
@@ -104,6 +105,7 @@ func (fsrv *FServer) decreaseActiveUploads() {
 	// decrease active uploads and semaphore.
 	fsrv.transferCfg.ActiveUploads--
 	<-fsrv.transferCfg.UpSem
+	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_UPLOADS, fsrv.transferCfg.ActiveUploads))
 }
 
 // function designed to check whether a file already exists.
@@ -132,6 +134,7 @@ func (fsrv *FServer) increaseActiveDownloads() {
 	// the semaphore and active uploads.
 	fsrv.transferCfg.DownSem <- struct{}{}
 	fsrv.transferCfg.ActiveDownloads++
+	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_DOWNLOADS, fsrv.transferCfg.ActiveDownloads))
 }
 
 // function designed to increment the number of "activeuploads"
@@ -141,6 +144,7 @@ func (fsrv *FServer) increaseActiveUploads() {
 	// the semaphore and active uploads.
 	fsrv.transferCfg.UpSem <- struct{}{}
 	fsrv.transferCfg.ActiveUploads++
+	fsrv.debugMessage(fmt.Sprintf(ofsmessages.DBG_ACTIVE_UPLOADS, fsrv.transferCfg.ActiveUploads))
 }
 
 // function designed to list out and return the files contained

--- a/server/serverprivate.go
+++ b/server/serverprivate.go
@@ -90,6 +90,22 @@ func (fsrv *FServer) debugMessageSuc(message string) {
 	}
 }
 
+// function designed to deccrement the number of "activedownloads"
+// for the client.
+func (fsrv *FServer) decreaseActiveDownloads() {
+	// decrease active downloads and semaphore.
+	fsrv.transferCfg.ActiveDownloads--
+	<-fsrv.transferCfg.DownSem
+}
+
+// function designed to deccrement the number of "activeuploads"
+// for the client.
+func (fsrv *FServer) decreaseActiveUploads() {
+	// decrease active uploads and semaphore.
+	fsrv.transferCfg.ActiveUploads--
+	<-fsrv.transferCfg.UpSem
+}
+
 // function designed to check whether a file already exists.
 //
 // if a file does exist, a nil error will be returned.
@@ -107,6 +123,24 @@ func (fsrv *FServer) fileExists(filename string) (err error) {
 	fsrv.debugMessageSuc(ofsmessages.DBG_FILENAME_VALID_SUC)
 
 	return nil
+}
+
+// function designed to increment the number of "activedownloads"
+// for the client.
+func (fsrv *FServer) increaseActiveDownloads() {
+	// wait for room in semaphore, then increase
+	// the semaphore and active uploads.
+	fsrv.transferCfg.DownSem <- struct{}{}
+	fsrv.transferCfg.ActiveDownloads++
+}
+
+// function designed to increment the number of "activeuploads"
+// for the client.
+func (fsrv *FServer) increaseActiveUploads() {
+	// wait for room in semaphore, then increase
+	// the semaphore and active uploads.
+	fsrv.transferCfg.UpSem <- struct{}{}
+	fsrv.transferCfg.ActiveUploads++
 }
 
 // function designed to list out and return the files contained

--- a/server/structs.go
+++ b/server/structs.go
@@ -30,6 +30,12 @@ type FServerOption struct {
 	// subdirectory within the rootdir where uploaded
 	// files will be saved.
 	Downloadsdir string
+	// number of maximum concurrent downloads the server is
+	// allowed to have active at one time.
+	MaxDownloads int
+	// number of maximum concurrent uploads the server is
+	// allowed to have active at one time.
+	MaxUploads int
 	// fileserver root directory.
 	Rootdir string
 	// subdirectory within the rootdir where files that

--- a/server/structs.go
+++ b/server/structs.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/tls"
+	"time"
 
 	"github.com/thomas-osgood/OGOR/output"
 	"github.com/thomas-osgood/ofs/protobufs/filehandler"
@@ -40,6 +41,8 @@ type FServerOption struct {
 	MaxUploads int
 	// fileserver root directory.
 	Rootdir string
+	// maximum allowed time a file upload or download can take.
+	TransferTimeout time.Duration
 	// subdirectory within the rootdir where files that
 	// can be downloaded to a client are stored.
 	Uploadsdir string

--- a/server/structs.go
+++ b/server/structs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/thomas-osgood/OGOR/output"
 	"github.com/thomas-osgood/ofs/protobufs/filehandler"
+	"github.com/thomas-osgood/ofs/server/internal/ofstypes"
 	"google.golang.org/grpc"
 )
 
@@ -18,6 +19,7 @@ type FServer struct {
 	downloadsdir string
 	printer      *output.Outputter
 	rootdir      string
+	transferCfg  ofstypes.TransferConfig
 	uploadsdir   string
 }
 


### PR DESCRIPTION
## Description

Server now has transfer timeout, max uploads, and max downloads.

Semaphores and mutexes have been added to control the upload/download limits.

The semaphores have been implemented using buffered channels.
The mutexes have been implemented using `sync.Mutex` objects.

## Associated Issues

#25 : Multifile Upload v2