### PR TITLE
misc(server): Utility Funcs

### DIFF
--- a/server/internal/utils/functions.go
+++ b/server/internal/utils/functions.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 
 	ofscommon "github.com/thomas-osgood/ofs/internal/general"
 	"github.com/thomas-osgood/ofs/server/internal/messages"
@@ -41,6 +43,13 @@ func CheckDirPerms(dirpath string) (err error) {
 	}
 
 	return nil
+}
+
+// function designed to clean and return a passed in directory name.
+// this will strip any non-printable chars using TrimSpace, pass the
+// dirname through the filepath.Clean func, etc.
+func CleanDirname(dirname string) string {
+	return filepath.Clean(strings.TrimSpace(dirname))
 }
 
 // function designed to read the filename header value from

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -129,11 +128,10 @@ func WithDirRoot(dirpath string) FSrvOptFunc {
 // set the downloads directory within the root directory.
 func WithDownloadsDir(dirname string) FSrvOptFunc {
 	return func(fo *FServerOption) error {
-		dirname = strings.TrimSpace(dirname)
+		dirname = ofsutils.CleanDirname(dirname)
 		if len(dirname) < 1 {
 			return fmt.Errorf(ofsmessages.ERR_DIRSTRING_EMPTY)
 		}
-		dirname = filepath.Clean(dirname)
 
 		fo.Downloadsdir = dirname
 
@@ -185,11 +183,10 @@ func WithTransferTimeout(timeout time.Duration) FSrvOptFunc {
 // set the uploads directory within the root directory.
 func WithUploadsDir(dirname string) FSrvOptFunc {
 	return func(fo *FServerOption) error {
-		dirname = strings.TrimSpace(dirname)
+		dirname = ofsutils.CleanDirname(dirname)
 		if len(dirname) < 1 {
 			return fmt.Errorf(ofsmessages.ERR_DIRSTRING_EMPTY)
 		}
-		dirname = filepath.Clean(dirname)
 
 		fo.Uploadsdir = dirname
 

--- a/server/server.go
+++ b/server/server.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -219,13 +218,13 @@ func (fsrv *FServer) StorageBreakdown(ctx context.Context, mpty *protocommon.Emp
 	consumption = new(filehandler.StorageInfo)
 
 	// get total consumption of downloads directory.
-	consumption.Downloads, err = fsrv.calculateDirectoryConsumption(filepath.Join(fsrv.rootdir, fsrv.downloadsdir))
+	consumption.Downloads, err = fsrv.calculateDirectoryConsumption(fsrv.buildDownloadDirPath())
 	if err != nil {
 		return nil, err
 	}
 
 	// get total consumption of uploads directory.
-	consumption.Uploads, err = fsrv.calculateDirectoryConsumption(filepath.Join(fsrv.rootdir, fsrv.uploadsdir))
+	consumption.Uploads, err = fsrv.calculateDirectoryConsumption(fsrv.buildUploadDirPath())
 	if err != nil {
 		return nil, err
 	}

--- a/server/serverprivate.go
+++ b/server/serverprivate.go
@@ -36,6 +36,18 @@ func (fsrv *FServer) buildDirStructure() (err error) {
 	return nil
 }
 
+// function designed to build and return the absolute path to the
+// downloads directory.
+func (fsrv *FServer) buildDownloadDirPath() string {
+	return filepath.Join(fsrv.rootdir, fsrv.downloadsdir)
+}
+
+// function designed to build and return the absolute path to the
+// uploads directory.
+func (fsrv *FServer) buildUploadDirPath() string {
+	return filepath.Join(fsrv.rootdir, fsrv.uploadsdir)
+}
+
 // function designed to build and return the absolute path to a file
 // in the uploads directory.
 func (fsrv *FServer) buildUploadFilename(filename string) string {


### PR DESCRIPTION
## Description

Added new helper functions for the server:

- **buildDownloadDirPath:** generates absolute path to the downloads directory. (part of `FServer` object)
- **buildUploadDirPath:** generates absolute path to the uploads directory. (part of `FServer` object)
- **CleanDirname:** strips spaces using `strings.TrimSpace`, runs the dirname through `filepath.Clean` and returns the result. (part of `internal/utils` module)

## Associated Issues

None