### PR TITLE
feat(authentication): Authentication Interface

### DIFF
--- a/ofsauthenticators/generics.go
+++ b/ofsauthenticators/generics.go
@@ -1,0 +1,6 @@
+package ofsauthenticators
+
+// generic interface defining an authentication request.
+type AuthRequest interface {
+	TokenRequest | UserPassRequest
+}

--- a/ofsauthenticators/interfaces.go
+++ b/ofsauthenticators/interfaces.go
@@ -2,6 +2,6 @@ package ofsauthenticators
 
 // interface defining an object that can be used to
 // authenticate client requests to the server.
-type OFSAuthenticator[T AuthRequest] interface {
-	ValidateUser(T) error
+type OFSAuthenticator interface {
+	ValidateUser(interface{}) error
 }

--- a/ofsauthenticators/interfaces.go
+++ b/ofsauthenticators/interfaces.go
@@ -1,0 +1,7 @@
+package ofsauthenticators
+
+// interface defining an object that can be used to
+// authenticate client requests to the server.
+type OFSAuthenticator[T AuthRequest] interface {
+	ValidateUser(T) error
+}

--- a/ofsauthenticators/interfaces.go
+++ b/ofsauthenticators/interfaces.go
@@ -1,7 +1,12 @@
 package ofsauthenticators
 
+import "google.golang.org/grpc/metadata"
+
 // interface defining an object that can be used to
 // authenticate client requests to the server.
 type OFSAuthenticator interface {
-	ValidateUser(interface{}) error
+	// function designed to parse metadata passed into it,
+	// pull out the correct credential headers and verify
+	// whether the given credentials are valid for a user.
+	ValidateUser(metadata.MD) error
 }

--- a/ofsauthenticators/structs.go
+++ b/ofsauthenticators/structs.go
@@ -1,0 +1,12 @@
+package ofsauthenticators
+
+// struct used to pass a token credential.
+type TokenRequest struct {
+	Token string `json:"token" xml:"token"`
+}
+
+// struct used to pass a username-password credential.
+type UserPassRequest struct {
+	Username string `json:"username" xml:"username"`
+	Password string `json:"password" xml:"password"`
+}

--- a/server/ofsfunctions.go
+++ b/server/ofsfunctions.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/thomas-osgood/OGOR/output"
+	"github.com/thomas-osgood/ofs/ofsauthenticators"
 	"github.com/thomas-osgood/ofs/ofsencryptors/ofsaesencryptor"
 	ofsdefaults "github.com/thomas-osgood/ofs/server/internal/defaults"
 	ofsmessages "github.com/thomas-osgood/ofs/server/internal/messages"
@@ -36,6 +37,7 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	}
 
 	defaults = FServerOption{
+		Authenticator:   nil,
 		Debug:           ofsdefaults.DEFAULT_DEBUG,
 		Downloadsdir:    ofsdefaults.DIR_DOWNLOADS,
 		Encryptor:       nil,
@@ -75,6 +77,7 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	// assign the server configuration to the server object
 	// that will be returned.
 	srv = new(FServer)
+	srv.authenticator = defaults.Authenticator
 	srv.debug = defaults.Debug
 	srv.downloadsdir = defaults.Downloadsdir
 	srv.encryptor = defaults.Encryptor
@@ -94,6 +97,15 @@ func NewOFS(opts ...FSrvOptFunc) (srv *FServer, err error) {
 	}
 
 	return srv, nil
+}
+
+// set the authenticator to use while processing
+// requests from clients.
+func WithAuthenticator(authenticator ofsauthenticators.OFSAuthenticator) FSrvOptFunc {
+	return func(fo *FServerOption) error {
+		fo.Authenticator = authenticator
+		return nil
+	}
 }
 
 // turn server debug mode on. this will cause messages to be printed

--- a/server/server.go
+++ b/server/server.go
@@ -25,6 +25,10 @@ import (
 
 // function designed to encrypt a file as requested by the client.
 func (fsrv *FServer) DecryptFile(ctx context.Context, fr *filehandler.FileRequest) (response *protocommon.StatusMessage, err error) {
+	// insure the request is valid.
+	if err = fsrv.validateRequest(ctx); err != nil {
+		return nil, err
+	}
 	err = fsrv.cryptoAction(fr.GetFilename(), ofsdefaults.ACT_DECRYPT)
 	if err != nil {
 		return &protocommon.StatusMessage{Code: http.StatusInternalServerError, Message: err.Error()}, err
@@ -36,6 +40,11 @@ func (fsrv *FServer) DecryptFile(ctx context.Context, fr *filehandler.FileReques
 // as requested by the client.
 func (fsrv *FServer) DeleteFile(ctx context.Context, req *filehandler.FileRequest) (resp *protocommon.StatusMessage, err error) {
 	var targetpath string = strings.TrimSpace(req.GetFilename())
+
+	// insure the request is valid.
+	if err = fsrv.validateRequest(ctx); err != nil {
+		return nil, err
+	}
 
 	resp = &protocommon.StatusMessage{
 		Code:    http.StatusOK,
@@ -70,6 +79,11 @@ func (fsrv *FServer) DownloadFile(srv filehandler.Fileservice_DownloadFileServer
 	var ctx context.Context
 	var filename string
 	var tmpname string
+
+	// insure the request is valid.
+	if err = fsrv.validateRequest(srv.Context()); err != nil {
+		return err
+	}
 
 	fsrv.increaseActiveDownloads()
 	defer fsrv.decreaseActiveDownloads()
@@ -115,6 +129,10 @@ func (fsrv *FServer) DownloadFile(srv filehandler.Fileservice_DownloadFileServer
 
 // function designed to encrypt a file as requested by the client.
 func (fsrv *FServer) EncryptFile(ctx context.Context, fr *filehandler.FileRequest) (response *protocommon.StatusMessage, err error) {
+	// insure the request is valid.
+	if err = fsrv.validateRequest(ctx); err != nil {
+		return nil, err
+	}
 	err = fsrv.cryptoAction(fr.GetFilename(), ofsdefaults.ACT_ENCRYPT)
 	if err != nil {
 		return &protocommon.StatusMessage{Code: http.StatusInternalServerError, Message: err.Error()}, err
@@ -129,6 +147,11 @@ func (fsrv *FServer) EncryptFile(ctx context.Context, fr *filehandler.FileReques
 func (fsrv *FServer) ListFiles(mpty *protocommon.Empty, srv filehandler.Fileservice_ListFilesServer) (err error) {
 	var curfile *filehandler.FileInfo
 	var files []*filehandler.FileInfo
+
+	// insure the request is valid.
+	if err = fsrv.validateRequest(srv.Context()); err != nil {
+		return err
+	}
 
 	// gather all files in the uploads directory.
 	files, err = fsrv.listUploadsDir()
@@ -156,6 +179,11 @@ func (fsrv *FServer) ListFiles(mpty *protocommon.Empty, srv filehandler.Fileserv
 // failure code: 500 Internal Server Error
 func (fsrv *FServer) MakeDirectory(ctx context.Context, dirreq *filehandler.MakeDirectoryRequest) (retstatus *protocommon.StatusMessage, err error) {
 	var subdir string = fsrv.buildUploadFilename(dirreq.GetDirname())
+
+	// insure the request is valid.
+	if err = fsrv.validateRequest(ctx); err != nil {
+		return nil, err
+	}
 
 	// initialize the successful StatusMessage. if everything
 	// works as expected, this will not be modified.
@@ -202,6 +230,11 @@ func (fsrv *FServer) RenameFile(ctx context.Context, rnreq *filehandler.RenameFi
 	var absdest string = fsrv.buildUploadFilename(rnreq.GetNewfilename())
 	var abssrc string = fsrv.buildUploadFilename(rnreq.GetOldfilename())
 
+	// insure the request is valid.
+	if err = fsrv.validateRequest(ctx); err != nil {
+		return nil, err
+	}
+
 	resp = new(protocommon.StatusMessage)
 
 	// check for the existence of the destination file. if the
@@ -230,6 +263,11 @@ func (fsrv *FServer) RenameFile(ctx context.Context, rnreq *filehandler.RenameFi
 // function designed to calculate and return the amount of storage (in bytes)
 // consumed by the uploads and downloads directories.
 func (fsrv *FServer) StorageBreakdown(ctx context.Context, mpty *protocommon.Empty) (consumption *filehandler.StorageInfo, err error) {
+
+	// insure the request is valid.
+	if err = fsrv.validateRequest(ctx); err != nil {
+		return nil, err
+	}
 
 	// initialize return object. this is required so a nil reference error
 	// is not thrown.
@@ -274,6 +312,11 @@ func (fsrv *FServer) UploadFile(req *filehandler.FileRequest, srv filehandler.Fi
 	var fptr *os.File
 	var md metadata.MD = make(metadata.MD)
 	var targetfile string = fsrv.cleanFilename(req.GetFilename(), ofsdefaults.FTYPE_UPLOAD)
+
+	// insure the request is valid.
+	if err = fsrv.validateRequest(srv.Context()); err != nil {
+		return err
+	}
 
 	fsrv.increaseActiveUploads()
 	defer fsrv.decreaseActiveUploads()

--- a/server/servervalidations.go
+++ b/server/servervalidations.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	ofsmessages "github.com/thomas-osgood/ofs/server/internal/messages"
+	"google.golang.org/grpc/metadata"
+)
+
+// function designed to validate a request.
+//
+// if the request is deemed "valid", nil will be returned.
+func (fsrv *FServer) validateRequest(ctx context.Context) (err error) {
+	var md metadata.MD
+	var ok bool
+
+	// extract the metadata information from the incoming context
+	// that was passed in.
+	//
+	// if this is unreadable, return an error saying the metadata
+	// could not be read.
+	md, ok = metadata.FromIncomingContext(ctx)
+	if !ok {
+		return fmt.Errorf(ofsmessages.ERR_HEADER_METADATA)
+	}
+
+	// if an authenticator has been set, validate the user's identity.
+	// if this validation fails, return the error.
+	if fsrv.authenticator != nil {
+		if err = fsrv.authenticator.ValidateUser(md); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/server/structs.go
+++ b/server/structs.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/thomas-osgood/OGOR/output"
+	"github.com/thomas-osgood/ofs/ofsauthenticators"
 	"github.com/thomas-osgood/ofs/protobufs/filehandler"
 	"github.com/thomas-osgood/ofs/server/internal/ofstypes"
 	"google.golang.org/grpc"
@@ -16,18 +17,21 @@ import (
 type FServer struct {
 	filehandler.UnimplementedFileserviceServer
 
-	debug        bool
-	downloadsdir string
-	encryptor    OFSEncryptor
-	printer      *output.Outputter
-	rootdir      string
-	transferCfg  ofstypes.TransferConfig
-	uploadsdir   string
+	authenticator ofsauthenticators.OFSAuthenticator
+	debug         bool
+	downloadsdir  string
+	encryptor     OFSEncryptor
+	printer       *output.Outputter
+	rootdir       string
+	transferCfg   ofstypes.TransferConfig
+	uploadsdir    string
 }
 
 // object used to set the confiruation options for
 // a new fileserver.
 type FServerOption struct {
+	// authenticator to use while processing requests.
+	Authenticator ofsauthenticators.OFSAuthenticator
 	// if this is set to true, output will be printed to
 	// STDOUT while the server is running.
 	Debug bool


### PR DESCRIPTION
## Description

This PR contains the definition of a new interface `OFSAuthenticator`, which can be used to authenticate requests to the server. A new `validateRequest` function has been added to the server and placed at the beginning of all public functions except `Ping`. This function calls the `ValidateRequest` function of the `OFSAuthenticator` used by the server (if one has been assigned).

New Functions Include:

- `WithAuthenticator`: in `ofsfunctions.go`
- `validateRequest`: in `servervalidations.go`

New Interfaces Include:

- `OFSAuthenticator`

New Structs Include:

- `TokenRequest`: struct with `Token` field that can be used in authenticator functions.
- `UserPassRequest`: struct with `Username` and `Password` fields that can be used in authenticator functions.

## Associated Issues

#40 